### PR TITLE
Properly glob keys as separate arguments to read_multi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+1.5.1 (Next Release)
+--------------------
+
+* Fixed `read_multi` calls so as to enable proper cache reading behavior in stores other than `ActiveSupport::Cache::DalliStore` - [@macreery](http://github.com/macreery)
+
 1.5 (04/13/2013)
 ----------------
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "http://rubygems.org"
 
 gem "activesupport"
-gem "mongoid"
+gem "mongoid", ">= 3.0.0"
 gem "hpricot"
 
 group :development do

--- a/README.md
+++ b/README.md
@@ -288,5 +288,4 @@ Copyright and License
 
 MIT License, see [LICENSE](https://github.com/dblock/mongoid-cached-json/blob/master/LICENSE.md) for details.
 
-(c) 2012 [Art.sy Inc.](http://artsy.github.com) and [Contributors](https://github.com/dblock/mongoid-cached-json/blob/master/HISTORY.md)
-
+(c) 2012 [Art.sy Inc.](http://artsy.github.com) and [Contributors](https://github.com/dblock/mongoid-cached-json/blob/master/CHANGELOG.md)

--- a/lib/mongoid-cached-json/cached_json.rb
+++ b/lib/mongoid-cached-json/cached_json.rb
@@ -158,7 +158,7 @@ module Mongoid
     def self.materialize_json_references_with_read_multi(key_refs, partial_json)
       unfrozen_keys = key_refs.keys.to_a.map(&:dup) if key_refs # see https://github.com/mperham/dalli/pull/320
       read_multi = unfrozen_keys && Mongoid::CachedJson.config.cache.respond_to?(:read_multi)
-      local_cache = read_multi ? Mongoid::CachedJson.config.cache.read_multi(unfrozen_keys) : {}
+      local_cache = read_multi ? Mongoid::CachedJson.config.cache.read_multi(*unfrozen_keys) : {}
       Mongoid::CachedJson.materialize_json_references(key_refs, local_cache, read_multi) if key_refs
       partial_json
     end

--- a/mongoid-cached-json.gemspec
+++ b/mongoid-cached-json.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Aaron Windsor", "Daniel Doubrovkine", "Frank Macreery"]
-  s.date = "2013-03-13"
+  s.date = "2013-05-06"
   s.description = "Cached-json is a DSL for describing JSON representations of Mongoid models."
   s.email = "dblock@dblock.org"
   s.extra_rdoc_files = [
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.homepage = "http://github.com/dblock/mongoid-cached-json"
   s.licenses = ["MIT"]
   s.require_paths = ["lib"]
-  s.rubygems_version = "1.8.25"
+  s.rubygems_version = "1.8.24"
   s.summary = "Effective model-level JSON caching for the Mongoid ODM."
 
   if s.respond_to? :specification_version then
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<activesupport>, [">= 0"])
-      s.add_runtime_dependency(%q<mongoid>, [">= 0"])
+      s.add_runtime_dependency(%q<mongoid>, [">= 3.0.0"])
       s.add_runtime_dependency(%q<hpricot>, [">= 0"])
       s.add_development_dependency(%q<rspec>, ["~> 2.5"])
       s.add_development_dependency(%q<bundler>, ["~> 1.0"])
@@ -46,7 +46,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<dalli>, ["~> 2.6"])
     else
       s.add_dependency(%q<activesupport>, [">= 0"])
-      s.add_dependency(%q<mongoid>, [">= 0"])
+      s.add_dependency(%q<mongoid>, [">= 3.0.0"])
       s.add_dependency(%q<hpricot>, [">= 0"])
       s.add_dependency(%q<rspec>, ["~> 2.5"])
       s.add_dependency(%q<bundler>, ["~> 1.0"])
@@ -56,7 +56,7 @@ Gem::Specification.new do |s|
     end
   else
     s.add_dependency(%q<activesupport>, [">= 0"])
-    s.add_dependency(%q<mongoid>, [">= 0"])
+    s.add_dependency(%q<mongoid>, [">= 3.0.0"])
     s.add_dependency(%q<hpricot>, [">= 0"])
     s.add_dependency(%q<rspec>, ["~> 2.5"])
     s.add_dependency(%q<bundler>, ["~> 1.0"])

--- a/spec/array_spec.rb
+++ b/spec/array_spec.rb
@@ -35,9 +35,7 @@ describe Array do
     it "uses a local cache to fetch repeated objects" do
       tool = Tool.create!({ :name => "hammer" })
       tool_key = "as_json/unspecified/Tool/#{tool.id}/all/true"
-      Mongoid::CachedJson.config.cache.should_receive(:read_multi).once.with([
-        tool_key
-      ]).and_return({
+      Mongoid::CachedJson.config.cache.should_receive(:read_multi).once.with(tool_key).and_return({
         tool_key => { :x => :y }
       })
       [ tool, tool, tool ].as_json({ properties: :all }).should == [

--- a/spec/dalli_spec.rb
+++ b/spec/dalli_spec.rb
@@ -23,7 +23,7 @@ describe ActiveSupport::Cache::DalliStore do
         tool2 = Tool.create!({ :name => "screwdriver" })
         tool2_key = Tool.cached_json_key(options, Tool, tool2.id)
         Mongoid::CachedJson.config.cache.should_not_receive(:fetch)
-        Mongoid::CachedJson.config.cache.should_receive(:read_multi).with([ tool1_key, tool2_key ]).once.and_return({
+        Mongoid::CachedJson.config.cache.should_receive(:read_multi).with(tool1_key, tool2_key).once.and_return({
           tool1_key => { :_id => tool1.id.to_s },
           tool2_key => { :_id => tool2.id.to_s }
         })

--- a/spec/hash_spec.rb
+++ b/spec/hash_spec.rb
@@ -49,9 +49,7 @@ describe Hash do
     it "uses a local cache to fetch repeated objects" do
       tool = Tool.create!({ :name => "hammer" })
       tool_key = "as_json/unspecified/Tool/#{tool.id}/all/true"
-      Mongoid::CachedJson.config.cache.should_receive(:read_multi).once.with([
-        tool_key
-      ]).and_return({
+      Mongoid::CachedJson.config.cache.should_receive(:read_multi).once.with(tool_key).and_return({
         tool_key => { :x => :y }
       })
       {

--- a/spec/mongoid_criteria_spec.rb
+++ b/spec/mongoid_criteria_spec.rb
@@ -42,7 +42,7 @@ describe Mongoid::Criteria do
         "as_json/unspecified/ToolBox/#{tool_box.id}/all/false",
         "as_json/unspecified/Tool/#{tool2.id}/all/true"
       ]
-      Mongoid::CachedJson.config.cache.should_receive(:read_multi).once.with(keys).and_return({
+      Mongoid::CachedJson.config.cache.should_receive(:read_multi).once.with(*keys).and_return({
         keys[0] => { :x => :y },
         keys[1] => { :x => :y },
         keys[2] => { :x => :y }
@@ -62,7 +62,7 @@ describe Mongoid::Criteria do
         "as_json/unspecified/ToolBox/#{tool_box.id}/all/false",
         "as_json/unspecified/Tool/#{tool2.id}/all/true"
       ]
-      Mongoid::CachedJson.config.cache.should_receive(:read_multi).once.with(keys).and_return({
+      Mongoid::CachedJson.config.cache.should_receive(:read_multi).once.with(*keys).and_return({
         keys[0] => { :x => :y },
         keys[1] => { :x => :y }
       })


### PR DESCRIPTION
Previously, read_multi was passing all keys as a single array, which works with `DalliStore`, but only due to a discrepancy in the behavior of `DalliStore` compared to the default (`ActiveSupport::Cache::Store`). This discrepancy has been addressed by mperham/dalli#362.

The upshot of this bug is that `Mongoid::CachedJson` would never actually utilize the cache with a cache other than `DalliStore`, and a call trace that hit `read_multi`. In particular, this degrades performance in most `:test` and `:development` environments, and introduces a discrepancy between `:test` and `:production`.
