### PR TITLE
Change back the default rake task to rubocop and spec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 
-script: bundle exec rake
+script: bundle exec rake spec
 
 services:
   - mongodb

--- a/Rakefile
+++ b/Rakefile
@@ -31,4 +31,4 @@ end
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new
 
-task default: :spec
+task default: [:rubocop, :spec]


### PR DESCRIPTION
I'm changing this based on the conversation here: https://github.com/mongoid/mongoid-cached-json/pull/20/files#r283951168

Also Travis builds can just run rake spec since we run a separate build for rubocop.