### PR TITLE
Do not test against Mongoid 7 and Ruby 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,3 +38,5 @@ matrix:
       env: MONGOID_VERSION=7
     - rvm: 2.1.10
       env: MONGOID_VERSION=7
+    - rvm: 2.2.10
+      env: MONGOID_VERSION=7


### PR DESCRIPTION
This started failing on Travis due to [the `i18n` gem not installing on Ruby 2.2](https://travis-ci.org/mongoid/mongoid-cached-json/jobs/539935941#L358). Given that Ruby 2.2. is not maintained and Mongoid 7 is the latest version of Mongoid as of this commit, I don't think it is critical to test against this combination.