### PR TITLE
fix: return false instead of nil for reference types, when value is false-y

### DIFF
--- a/lib/mongoid-cached-json/cached_json.rb
+++ b/lib/mongoid-cached-json/cached_json.rb
@@ -151,13 +151,11 @@ module Mongoid
           reference_def_definition = reference_def[:definition]
           reference = reference_def_definition.is_a?(Symbol) ? object.send(reference_def_definition) : reference_def_definition.call(object)
           reference_json = nil
-          if reference
-            if reference.respond_to?(:as_json_partial)
-              reference_keys, reference_json = reference.as_json_partial(options)
-              keys = keys ? keys.merge_set(reference_keys) : reference_keys
-            else
-              reference_json = reference.as_json(options)
-            end
+          if reference.respond_to?(:as_json_partial)
+            reference_keys, reference_json = reference.as_json_partial(options)
+            keys = keys ? keys.merge_set(reference_keys) : reference_keys
+          else
+            reference_json = reference.as_json(options)
           end
         end
         [keys, reference_json]

--- a/spec/cached_json_spec.rb
+++ b/spec/cached_json_spec.rb
@@ -496,6 +496,14 @@ describe Mongoid::CachedJson do
           expect(@image.as_json(properties: :all)).to eq(name: 'Image', urls: [])
         end
       end
+      context 'evaluating a false-y value in a reference type' do
+        it 'correctly returns false instead of nil' do
+          manager = JsonManager.create!(name: 'Boss')
+          manager.json_employees.create!(name: 'Matt')
+          manager_short_json = manager.as_json(properties: :short)
+          expect(manager_short_json[:has_left_handed_employee]).to eq(false)
+        end
+      end
     end
   end
 end

--- a/spec/support/json_employee.rb
+++ b/spec/support/json_employee.rb
@@ -4,6 +4,7 @@ class JsonEmployee
 
   field :name
   field :nickname, default: 'My Favorite'
+  field :is_left_handed, type: Boolean, default: false
   belongs_to :json_manager
 
   json_fields \

--- a/spec/support/json_manager.rb
+++ b/spec/support/json_manager.rb
@@ -12,8 +12,13 @@ class JsonManager
     belongs_to :supervisor, class_name: 'JsonSupervisor', required: false
   end
 
+  def has_left_handed_employee?
+    json_employees.any? { |e| e.is_left_handed? }
+  end
+
   json_fields \
     name: {},
     ssn: { properties: :all },
-    employees: { type: :reference, definition: :json_employees }
+    employees: { type: :reference, definition: :json_employees },
+    has_left_handed_employee: { type: :reference, definition: :has_left_handed_employee? }
 end


### PR DESCRIPTION
Noticing an odd bug where if a field has `type: :reference` _and_ the `definition` is something that returns `false`, the value of `nil` gets returned instead of the correct `false`.

👋 @dblock 